### PR TITLE
Remove triple is_required flag in sc-template-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ templ = ScTemplate()
 templ.triple([class_node_addr, '_class_node'], sc_types.EDGE_ACCESS_VAR_POS_PERM, node_addr) # faf
 templ.triple('_class_node', sc_types.EDGE_ACCESS_VAR_POS_TEMP, link_addr) # faf
 templ.triple('_class_node', edge_addr, sc_types.NODE_VAR) # ffa
-templ.triple(node_addr, edge_addr, sc_types.NODE_VAR, is_required=False) # ffa, can be empty
+templ.triple(node_addr, edge_addr, sc_types.NODE_VAR) # ffa
 search_results = client.template_search(templ)
 search_result = search_results[0]
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+ - Remove opportunity to not search some triples in sc-template, remove is_required flag,
+   deprecated by [ostis-ai/sc-machine@49c5406](https://github.com/ostis-ai/sc-machine/commit/49c540646ba795ca2e6879ec3d3c2f1aa94f79ca)
 
 ## [0.1.2]
 ### Changed

--- a/src/sc_client/models.py
+++ b/src/sc_client/models.py
@@ -59,7 +59,6 @@ class ScTemplateTriple(TypedDict):
     src: ScTemplateValue
     edge: ScTemplateValue
     trg: ScTemplateValue
-    is_required: bool
 
 
 class ScTemplate:
@@ -71,11 +70,10 @@ class ScTemplate:
         param1: ScTemplateParam,
         param2: ScTemplateParam,
         param3: ScTemplateParam,
-        is_required=True,
     ) -> None:
         p1, p2, p3 = tuple(map(self._split_template_param, [param1, param2, param3]))
 
-        self.triple_list.append(ScTemplateTriple(src=p1, edge=p2, trg=p3, is_required=is_required))
+        self.triple_list.append(ScTemplateTriple(src=p1, edge=p2, trg=p3))
 
     def triple_with_relation(
         self,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -293,7 +293,7 @@ class TestClientTemplate(ScTest):
         templ.triple([ScAddr(0), "_class_node"], sc_types.EDGE_ACCESS_VAR_POS_PERM, ScAddr(0))
         templ.triple("_class_node", sc_types.EDGE_ACCESS_VAR_POS_TEMP, ScAddr(0))
         templ.triple("_class_node", ScAddr(0), sc_types.NODE_VAR)
-        templ.triple(ScAddr(0), ScAddr(0), sc_types.NODE_VAR, is_required=False)
+        templ.triple(ScAddr(0), ScAddr(0), sc_types.NODE_VAR)
         search_result_list = client.template_search(templ)
 
         assert len(search_result_list) != 0


### PR DESCRIPTION
Opportunity to not search some triples in template is deprecated by commit https://github.com/ostis-ai/sc-machine/commit/49c540646ba795ca2e6879ec3d3c2f1aa94f79ca.